### PR TITLE
MdePkg/Library: RISC-V: Management Mode support in RAS agent client

### DIFF
--- a/MdeModulePkg/MdeModulePkg.dsc
+++ b/MdeModulePkg/MdeModulePkg.dsc
@@ -540,5 +540,13 @@
   MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmCoreLib.inf
   MdeModulePkg/Library/ArmFfaLib/ArmFfaStandaloneMmLib.inf
 
+[Components.RISCV64]
+  MdeModulePkg/Universal/Acpi/AcpiHardwareErrorTableDxe/HardwareErrorSourceTableDxe.inf {
+    <LibraryClasses>
+      CommonRiscvMpxyLib|MdePkg/Library/CommonRiscvMpxyLib/CommonRiscvMpxy.inf
+      DxeRasAgentClientLib|MdePkg/Library/DxeRiscvRasAgentClientLib/DxeRiscvRasAgentClientLib.inf
+      RiscVSbiLib|MdePkg/Library/BaseRiscVSbiLib/BaseRiscVSbiLib.inf
+  }
+
 [BuildOptions]
 

--- a/MdeModulePkg/Universal/Acpi/AcpiHardwareErrorTableDxe/HardwareErrorSourceTableDxe.c
+++ b/MdeModulePkg/Universal/Acpi/AcpiHardwareErrorTableDxe/HardwareErrorSourceTableDxe.c
@@ -1,0 +1,247 @@
+/** @file
+  This module installs ACPI Hardware Error Source Table (HEST)
+
+  Copyright (c) 2024, Ventana Micro Systems, Inc.
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Base.h>
+#include <Uefi.h>
+
+#include <IndustryStandard/Acpi.h>
+
+#include <Protocol/AcpiTable.h>
+
+#include <Guid/EventGroup.h>
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PcdLib.h>
+#include <Library/SafeIntLib.h>
+#include <Library/BaseRiscVSbiLib.h>
+
+#include <Library/DxeRiscvMpxy.h>
+#include <Library/DxeRasAgentClient.h>
+
+EFI_EVENT  mHestReadyToBootEvent;
+UINTN      mHestTableKey          = 0;
+BOOLEAN    mAcpiHestInstalled     = FALSE;
+BOOLEAN    mAcpiHestStatusChanged = FALSE;
+BOOLEAN    mAcpiHestBufferChanged = FALSE;
+
+#define STATUS_BLOCK_SIZE  1024
+#define MPXY_SHMEM_SIZE    4096
+
+//
+// ACPI Hardware Error Source Table template
+//
+EFI_ACPI_6_5_HARDWARE_ERROR_SOURCE_TABLE_HEADER  mHestTemplate = {
+  {
+    EFI_ACPI_6_5_HARDWARE_ERROR_SOURCE_TABLE_SIGNATURE,
+    sizeof (EFI_ACPI_6_5_HARDWARE_ERROR_SOURCE_TABLE_HEADER),
+    EFI_ACPI_6_5_HARDWARE_ERROR_SOURCE_TABLE_REVISION, // Revision
+    0x00,                                              // Checksum will be updated at runtime
+    //
+    // It is expected that these values will be updated at EntryPoint.
+    //
+    { 0x00 },   // OEM ID is a 6 bytes long field
+    0x00,       // OEM Table ID(8 bytes long)
+    0x00,       // OEM Revision
+    0x00,       // Creator ID
+    0x00,       // Creator Revision
+  },
+  0             // Number of error source
+};
+
+/**
+  Notify function for event group EFI_EVENT_GROUP_READY_TO_BOOT. This is used to
+  install the Hardware Error Source Table.
+
+  @param[in]  Event   The Event that is being processed.
+  @param[in]  Context The Event Context.
+
+**/
+VOID
+EFIAPI
+HestReadyToBootEventNotify (
+  IN EFI_EVENT  Event,
+  IN VOID       *Context
+  )
+{
+  EFI_STATUS                                                      Status;
+  EFI_ACPI_TABLE_PROTOCOL                                         *AcpiTableProtocol;
+  EFI_ACPI_DESCRIPTION_HEADER                                     *Header;
+  VOID                                                            *ErrDesc;
+  UINT32                                                          NumSources, *ErrSources, ErrDescSize;
+  INTN                                                            i;
+  VOID                                                            *HestTable;
+  UINT32                                                          HestPages, HestTableSize;
+  UINTN                                                           DescriptorType;
+  EFI_ACPI_6_5_GENERIC_HARDWARE_ERROR_SOURCE_VERSION_2_STRUCTURE  *BaseErrSrcStructure, *tESS;
+
+  #define HEST_TO_BASE_ERROR_STRUCTURE(_table)                            \
+  (EFI_ACPI_6_5_GENERIC_HARDWARE_ERROR_SOURCE_VERSION_2_STRUCTURE *)    \
+    ((UINT8 *)_table +                                                  \
+     sizeof(typeof(EFI_ACPI_6_5_HARDWARE_ERROR_SOURCE_TABLE_HEADER)));
+
+  Header = &mHestTemplate.Header;
+
+  //
+  // Get ACPI Table protocol.
+  //
+  Status = gBS->LocateProtocol (
+                  &gEfiAcpiTableProtocolGuid,
+                  NULL,
+                  (VOID **)&AcpiTableProtocol
+                  );
+  if (EFI_ERROR (Status)) {
+    return;
+  }
+
+  //
+  // Check if HEST is already installed.
+  //
+  if (mAcpiHestInstalled) {
+    Status = AcpiTableProtocol->UninstallAcpiTable (
+                                  AcpiTableProtocol,
+                                  mHestTableKey
+                                  );
+    if (EFI_ERROR (Status)) {
+      return;
+    }
+  }
+
+  // Initialize the RAS agent client library.
+  Status = RacInit ();
+  if (EFI_ERROR (Status)) {
+    return;
+  }
+
+  // Fetch the number of hardware error sources available
+  Status = RacGetNumberErrorSources (&NumSources);
+  if (EFI_ERROR (Status)) {
+    return;
+  }
+
+  // Fetch the unique source ID for each error source.
+  Status = RacGetErrorSourceIDList (&ErrSources, &NumSources);
+  if (EFI_ERROR (Status)) {
+    return;
+  }
+
+  mHestTemplate.ErrorSourceCount = NumSources;
+
+  // Allocate memory for all the error source descriptors
+  HestTableSize = sizeof (mHestTemplate) +
+                  sizeof (EFI_ACPI_6_5_GENERIC_HARDWARE_ERROR_SOURCE_VERSION_2_STRUCTURE)
+                  * NumSources;
+  HestPages = EFI_SIZE_TO_PAGES (HestTableSize);
+  HestTable = AllocateAlignedPages (HestPages, 4096);
+
+  if (HestTable == NULL) {
+    return;
+  }
+
+  CopyMem (HestTable, &mHestTemplate, sizeof (mHestTemplate));
+
+  tESS = BaseErrSrcStructure = HEST_TO_BASE_ERROR_STRUCTURE (HestTable);
+
+  for (i = 0; i < NumSources; i++) {
+    Status = RacGetErrorSourceDescriptor (
+               ErrSources[i],
+               &DescriptorType,
+               &ErrDesc,
+               &ErrDescSize
+               );
+    if (EFI_ERROR (Status)) {
+      return;
+    }
+
+    ASSERT (DescriptorType == DT_GHESV2);
+
+    CopyMem (tESS, ErrDesc, ErrDescSize);
+    tESS++;
+  }
+
+  Header         = &((typeof(mHestTemplate) *) HestTable)->Header;
+  Header->Length = HestTableSize;
+  //
+  // Update Checksum in Hest Table
+  //
+  Header->Checksum = 0;
+  Header->Checksum =
+    CalculateCheckSum8 (
+      (UINT8 *)&HestTable,
+      HestTableSize
+      );
+
+  //
+  // Publish Boot Graphics Resource Table.
+  //
+  Status = AcpiTableProtocol->InstallAcpiTable (
+                                AcpiTableProtocol,
+                                HestTable,
+                                HestTableSize,
+                                &mHestTableKey
+                                );
+  if (EFI_ERROR (Status)) {
+    return;
+  }
+
+  mAcpiHestInstalled = TRUE;
+}
+
+/**
+  The module Entry Point of the Boot Graphics Resource Table DXE driver.
+
+  @param[in]  ImageHandle    The firmware allocated handle for the EFI image.
+  @param[in]  SystemTable    A pointer to the EFI System Table.
+
+  @retval EFI_SUCCESS    The entry point is executed successfully.
+  @retval Other          Some error occurs when executing this entry point.
+
+**/
+EFI_STATUS
+EFIAPI
+HardwareErrorSourceDxeEntryPoint (
+  IN EFI_HANDLE        ImageHandle,
+  IN EFI_SYSTEM_TABLE  *SystemTable
+  )
+{
+  EFI_STATUS                   Status;
+  EFI_ACPI_DESCRIPTION_HEADER  *Header;
+
+  //
+  // Update Header fields of HEST
+  //
+  Header = &mHestTemplate.Header;
+  ZeroMem (Header->OemId, sizeof (Header->OemId));
+  CopyMem (
+    Header->OemId,
+    PcdGetPtr (PcdAcpiDefaultOemId),
+    MIN (PcdGetSize (PcdAcpiDefaultOemId), sizeof (Header->OemId))
+    );
+
+  WriteUnaligned64 (&Header->OemTableId, PcdGet64 (PcdAcpiDefaultOemTableId));
+  Header->OemRevision     = PcdGet32 (PcdAcpiDefaultOemRevision);
+  Header->CreatorId       = PcdGet32 (PcdAcpiDefaultCreatorId);
+  Header->CreatorRevision = PcdGet32 (PcdAcpiDefaultCreatorRevision);
+
+  //
+  // Register notify function to install HEST on ReadyToBoot Event.
+  //
+  Status = gBS->CreateEventEx (
+                  EVT_NOTIFY_SIGNAL,
+                  TPL_CALLBACK,
+                  HestReadyToBootEventNotify,
+                  NULL,
+                  &gEfiEventReadyToBootGuid,
+                  &mHestReadyToBootEvent
+                  );
+  ASSERT_EFI_ERROR (Status);
+
+  return Status;
+}

--- a/MdeModulePkg/Universal/Acpi/AcpiHardwareErrorTableDxe/HardwareErrorSourceTableDxe.inf
+++ b/MdeModulePkg/Universal/Acpi/AcpiHardwareErrorTableDxe/HardwareErrorSourceTableDxe.inf
@@ -1,0 +1,61 @@
+## @file
+#  This module install ACPI Hardware Error Source Table (HEST)
+#
+#  Copyright (c) 2024, Ventana Micro Systems, Inc.
+#  SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION                    = 0x00010005
+  BASE_NAME                      = HardwareErrorSourceTableDxe
+  MODULE_UNI_FILE                = HardwareErrorSourceTableDxe.uni
+  FILE_GUID                      = 79ecd602-f3b0-4780-9eed-d744229428e3
+  MODULE_TYPE                    = UEFI_DRIVER
+  VERSION_STRING                 = 1.0
+  ENTRY_POINT                    = HardwareErrorSourceDxeEntryPoint
+
+#
+# The following information is for reference only and not required by the build tools.
+#
+#  VALID_ARCHITECTURES           = RISCV64
+#
+
+[Sources]
+  HardwareErrorSourceTableDxe.c
+
+[Packages]
+  MdePkg/MdePkg.dec
+  MdeModulePkg/MdeModulePkg.dec
+
+[LibraryClasses]
+  BaseLib
+  BaseMemoryLib
+  DebugLib
+  MemoryAllocationLib
+  PcdLib
+  SafeIntLib
+  UefiBootServicesTableLib
+  UefiDriverEntryPoint
+  UefiLib
+
+[LibraryClasses.RISCV64]
+  CommonRiscvMpxyLib
+  DxeRasAgentClientLib
+  RiscVSbiLib
+
+[Protocols]
+  gEfiAcpiTableProtocolGuid                     ## CONSUMES
+
+[Pcd]
+  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultOemId            ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultOemTableId       ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultOemRevision      ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultCreatorId        ## CONSUMES
+  gEfiMdeModulePkgTokenSpaceGuid.PcdAcpiDefaultCreatorRevision  ## CONSUMES
+
+[Guids]
+  gEfiEventReadyToBootGuid                      ## CONSUMES ## Event
+
+[UserExtensions.TianoCore."ExtraFiles"]
+  HardwareErrorSourceTableDxeExtra.uni

--- a/MdeModulePkg/Universal/Acpi/AcpiHardwareErrorTableDxe/HardwareErrorSourceTableDxe.uni
+++ b/MdeModulePkg/Universal/Acpi/AcpiHardwareErrorTableDxe/HardwareErrorSourceTableDxe.uni
@@ -1,0 +1,14 @@
+// /** @file
+// This module install ACPI Hardware Error Source Table (HEST).
+//
+// Copyright (c) 2024, Ventana Micro Systems, Inc.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+
+#string STR_MODULE_ABSTRACT             #language en-US "Installs ACPI Hardware Error Source Table (HEST)"
+
+#string STR_MODULE_DESCRIPTION          #language en-US "This module installs the ACPI Hardware Error Source Table (HEST)"
+

--- a/MdeModulePkg/Universal/Acpi/AcpiHardwareErrorTableDxe/HardwareErrorSourceTableDxeExtra.uni
+++ b/MdeModulePkg/Universal/Acpi/AcpiHardwareErrorTableDxe/HardwareErrorSourceTableDxeExtra.uni
@@ -1,0 +1,14 @@
+// /** @file
+// HardwareErrorSourceTableDxe Localized Strings and Content
+//
+// Copyright (c) 2024, Ventana Micro Systems, Inc.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+// **/
+
+#string STR_PROPERTIES_MODULE_NAME
+#language en-US
+"ACPI Hardware Error Source Table DXE Driver"
+
+

--- a/MdePkg/Include/Library/DxeRasAgentClient.h
+++ b/MdePkg/Include/Library/DxeRasAgentClient.h
@@ -1,0 +1,82 @@
+/** @file
+  This module provides communication with RAS Agent over RPMI/MPXY
+
+  Copyright (c) 2024, Ventana Micro Systems, Inc.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef _RAS_AGENT_CLIENT_H
+#define _RAS_AGENT_CLIENT_H
+
+typedef enum {
+  DT_GHESV2,
+  NUM_ERR_DESC_TYPES
+} ErrorDescriptorType;
+
+#define ERROR_DESCRIPTOR_TYPE_SHIFT  4
+#define MAX_ERROR_DESCRIPTOR_TYPES   (0x1UL << ERROR_DESCRIPTOR_TYPE_SHIFT)
+#define ERROR_DESCRIPTOR_TYPE_MASK   (MAX_ERROR_DESCRIPTOR_TYPES - 1)
+
+/**
+  Initialize the RAS agent client
+
+  @retval EFI_SUCCESS  If initialization is successful
+**/
+EFI_STATUS
+EFIAPI
+RacInit (
+  VOID
+  );
+
+/**
+  Get the number of hardware error sources from the RAS Agent
+
+  @param NumErrorSources  Pointer to an array of 32-bit integers which will
+                          contain number of hardware error sources available.
+
+  @retval EFI_SUCCESS  If fetching the number of error sources succeeded.
+**/
+EFI_STATUS
+EFIAPI
+RacGetNumberErrorSources (
+  OUT UINT32  *NumErrorSources
+  );
+
+/**
+  Get the list of hardware error source IDs from the RAS Agent
+
+  @param ErrorSourceList  Will contain pointer to error of 32-bit integers
+                          containing the error source IDs.
+  @param NumSources       Will contain the number of IDs in *ErrorSourceList
+
+  @retval EFI_SUCCESS  If fetching the error source IDs succeeded.
+**/
+EFI_STATUS
+EFIAPI
+RacGetErrorSourceIDList (
+  OUT UINT32  **ErrorSourceList,
+  OUT UINT32  *NumSources
+  );
+
+/**
+  Get the hardware error source descriptor for a given error source ID.
+
+  @param SourceID  Error source ID for which descriptor is to be fetched
+  @param DescriptorType  Type of error descritor (GHESv2 or platform specific)
+  @param ErrorDesciptor  Pointer to buffer containing the descriptor. The caller
+                         must free the buffer when done.
+  @param ErrorDescriptorSize  Size of the error descriptor buffer in ErrorDescriptor
+
+  @retval EFI_SUCCESS  On success.
+**/
+EFI_STATUS
+EFIAPI
+RacGetErrorSourceDescriptor (
+  IN UINT32   SourceID,
+  OUT UINTN   *DescriptorType,
+  OUT VOID    **ErrorDescriptor,
+  OUT UINT32  *ErrorDescriptorSize
+  );
+
+#endif

--- a/MdePkg/Include/Library/DxeRiscvMpxy.h
+++ b/MdePkg/Include/Library/DxeRiscvMpxy.h
@@ -1,0 +1,122 @@
+/** @file
+  This module implements functions to be used by MPXY client
+
+  Copyright (c) 2024, Ventana Micro Systems, Inc.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#ifndef SBI_MPXY_H_
+#define SBI_MPXY_H_
+
+typedef enum {
+  MpxyChanAttrProtId,
+  MpxyChanAttrProtVersion,
+  MpxyChanAttrMsgDataMaxLen,
+  MpxyChanAttrMsgSendTimeout,
+  MpxyChanAttrMsgCompletionTimeout,
+  MpxyChanAttrCapability,
+  MpxyChanAttrSseEventId,
+  MpxyChanAttrMsiControl,
+  MpxyChanAttrMsiAddrLow,
+  MpxyChanAttrMsiAddrHigh,
+  MpxyChanAttrMsiData,
+  MpxyChanAttrEventStateControl,
+  MpxyChanAttrMax
+} SBI_MPXY_CHAN_ATTR;
+
+#define MPXY_MSG_PROTO_ATTR_START  0x80000000
+#define MPXY_MSG_PROTO_ATTR_END    0xffffffff
+
+/**
+  Get the list of channels available on MPXY.
+
+  @param[in] StartIndex - Index to start reading from. Initially it will be zero,
+             after subsequent reads, it will be the last index read + 1.
+  @param[out] List of the channels available.
+  @param[out] Number of channels remaining.
+  @param[out] Number of channels retruned in this read.
+
+  @retval EFI_SUCCESS   If list of channels was obtained successfully.
+**/
+EFI_STATUS
+EFIAPI
+SbiMpxyGetChannelList (
+  IN  UINTN  StartIndex,
+  OUT UINTN  *ChannelList,
+  OUT UINTN  *Remaining,
+  OUT UINTN  *Returned
+  );
+
+/**
+  Read the attributes (both base and protocol specific) of a channel
+
+  @param[in] Channel for which attributes are to be read
+  @param[in] The base attribute ID
+  @param[in] Number of attributes to be read
+  @param[out] Attributes read from channel from base attributes Id
+
+  @retval EFI_SUCCESS If the attributes were read successfully
+**/
+
+EFI_STATUS
+EFIAPI
+SbiMpxyReadChannelAttrs (
+  IN UINTN    ChannelId,
+  IN UINT32   BaseAttrId,
+  IN UINT32   NrAttrs,
+  OUT UINT32  *Attrs
+  );
+
+/**
+  Open specified MPXY channel for communication. It will allocate the shared
+  memory or resize the previous one if required.
+
+  @param[in] ChannelId  The channel to be initialized
+  @retval EFI_SUCCESS   If the allocation or resize of shared memory was
+                        successfully done.
+**/
+EFI_STATUS
+EFIAPI
+SbiMpxyInit (
+  VOID
+  );
+
+/**
+  Close the specified MPXY channel.
+
+  @param[in] ChannelId  The channel to be uninitialized
+  @retval EFI_SUCCESS   If the allocation or resize of shared memory was
+                        successfully done.
+**/
+EFI_STATUS
+EFIAPI
+SbiMpxyDeinit (
+  VOID
+  );
+
+/**
+  Send a message with response over Mpxy.
+
+  @param[in] ChannelId       The Channel on which message would be sent
+  @param[in] MessageId       Message protocol specific message identification
+  @param[in] MessageDataLen  Length of the message to be sent
+  @param[in] Message         Pointer to buffer containing message
+  @param[in] Response        Pointer to buffer to which response should be written
+  @param[in] ResponseLen     Pointer where the size of response should be written
+
+  @retval EFI_SUCCESS    The shared memory was disabled
+  @retval Other          Some error occured during the operation
+**/
+EFI_STATUS
+EFIAPI
+SbiMpxySendMessage (
+  IN UINTN   ChannelId,
+  IN UINTN   MessageId,
+  IN VOID    *Message,
+  IN UINTN   MessageDataLen,
+  OUT VOID   *Response,
+  OUT UINTN  *ResponseLen
+  );
+
+#endif

--- a/MdePkg/Library/CommonRiscvMpxyLib/CommonRiscvMpxy.c
+++ b/MdePkg/Library/CommonRiscvMpxyLib/CommonRiscvMpxy.c
@@ -1,0 +1,488 @@
+/** @file
+  This module implements functions to be used by MPXY client.
+
+  It facilitates communication with the SBI MPXY extension for shared memory
+  configuration, channel querying, and attribute reading.
+
+  Copyright (c) 2024, Ventana Micro Systems, Inc.
+  Copyright (c) 2025, Rivos Inc.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Base.h>
+#include <Uefi.h>
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PcdLib.h>
+#include <Library/SafeIntLib.h>
+#include <Library/BaseRiscVSbiLib.h>
+#include <Library/DxeRiscvMpxy.h>
+
+#define INVAL_PHYS_ADDR  (-1U)
+#define INVALID_CHAN     -1
+
+#define MPXY_SHMEM_SIZE  4096
+
+#if defined (__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define LLE_TO_CPU(x)  (SwapBytes64(x))
+#define CPU_TO_LLE(x)  (SwapBytes64(x))
+#else
+#define LLE_TO_CPU(x)  (x)
+#define CPU_TO_LLE(x)  (x)
+#endif
+
+STATIC VOID     *gShmemVirt         = NULL;
+STATIC UINTN    gNrShmemPages       = 0;
+STATIC UINT64   gShmemPhysHi        = INVAL_PHYS_ADDR;
+STATIC UINT64   gShmemPhysLo        = INVAL_PHYS_ADDR;
+STATIC UINT64   gShmemSize          = 0;
+STATIC BOOLEAN  gMpxyLibInitialized = FALSE;
+STATIC UINT64   gShmemSet           = 0;
+
+STATIC
+EFI_STATUS
+EFIAPI
+SbiMpxyGetShmemSize (
+  OUT UINT64  *ShmemSize
+  )
+{
+  SBI_RET  Ret;
+
+  Ret = SbiCall (
+          SBI_EXT_MPXY,
+          SBI_EXT_MPXY_GET_SHMEM_SIZE,
+          0
+          );
+
+  if (Ret.Error == SBI_SUCCESS) {
+    *ShmemSize = Ret.Value;
+    return EFI_SUCCESS;
+  }
+
+  return TranslateError (Ret.Error);
+}
+
+/**
+  Configure the shared memory physical address using SBI MPXY extension.
+
+  @param[in]  ShmemPhysHi   High Addr physical address.
+  @param[in]  ShmemPhysLo   Low Addr physical address.
+
+  @retval EFI_SUCCESS           The operation completed successfully.
+  @retval EFI_DEVICE_ERROR      SBI call failed or invalid parameters.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+SbiMpxySetShmem (
+  IN UINT64   ShmemPhysHi,
+  IN UINT64   ShmemPhysLo,
+  OUT UINT64  *PrevShmemPhysHi,
+  OUT UINT64  *PrevShmemPhysLo,
+  BOOLEAN     ReadBackOldShmem
+  )
+{
+  SBI_RET  Ret;
+  UINT32   Flags = 0b00;
+  UINT64   *PrevMemDet;
+
+  if (ReadBackOldShmem) {
+    Flags = 0b01;
+  }
+
+  Ret = SbiCall (
+          SBI_EXT_MPXY,
+          SBI_EXT_MPXY_SET_SHMEM,
+          3,
+          CPU_TO_LLE (ShmemPhysLo),
+          CPU_TO_LLE (ShmemPhysHi),
+          Flags
+          );
+
+  if (Ret.Error == SBI_SUCCESS) {
+    if ((ShmemPhysLo == INVAL_PHYS_ADDR) && (ShmemPhysHi == INVAL_PHYS_ADDR)) {
+      gShmemPhysHi = INVAL_PHYS_ADDR;
+      gShmemPhysLo = INVAL_PHYS_ADDR;
+      gShmemSet    = 0;
+      return EFI_SUCCESS;
+    }
+
+    gShmemPhysLo = ShmemPhysLo;
+    gShmemPhysHi = ShmemPhysHi;
+    gShmemSet    = 1;
+
+    PrevMemDet = (UINT64 *)gShmemPhysLo;
+
+    if (ReadBackOldShmem) {
+      *PrevShmemPhysLo = LLE_TO_CPU (PrevMemDet[0]);
+      *PrevShmemPhysHi = LLE_TO_CPU (PrevMemDet[1]);
+    }
+  }
+
+  return TranslateError (Ret.Error);
+}
+
+/**
+  Disable shared memory by resetting the physical address.
+
+  @retval EFI_SUCCESS           Successfully disabled.
+  @retval EFI_DEVICE_ERROR      SBI call failed.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+SbiMpxyDisableShmem (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+
+  if (!gShmemSet) {
+    return EFI_SUCCESS;
+  }
+
+  Status = SbiMpxySetShmem (
+             INVAL_PHYS_ADDR,
+             INVAL_PHYS_ADDR,
+             NULL,
+             NULL,
+             FALSE
+             );
+
+  return Status;
+}
+
+/**
+  Check whether MPXY shared memory is initialized.
+
+  @retval TRUE     Initialized.
+  @retval FALSE    Not initialized.
+**/
+BOOLEAN
+SbiMpxyShmemInitialized (
+  VOID
+  )
+{
+  return gMpxyLibInitialized;
+}
+
+/**
+  Retrieve the list of MPXY channel IDs.
+
+  @param[in]   StartIndex     Index to start from.
+  @param[out]  ChannelList    Pointer to array to hold channel IDs.
+  @param[out]  Remaining      Channels yet to be read.
+  @param[out]  Returned       Number of channels returned.
+
+  @retval EFI_SUCCESS         Channel list retrieved.
+  @retval EFI_DEVICE_ERROR    MPXY not initialized or SBI error.
+**/
+EFI_STATUS
+EFIAPI
+SbiMpxyGetChannelList (
+  IN  UINTN  StartIndex,
+  OUT UINTN  *ChannelList,
+  OUT UINTN  *Remaining,
+  OUT UINTN  *Returned
+  )
+{
+  UINT64      OPhysHi, OPhysLo;
+  EFI_STATUS  Status;
+  SBI_RET     Ret;
+  UINT32      *Shmem = gShmemVirt;
+  UINTN       i;
+
+  if (!gMpxyLibInitialized) {
+    return (EFI_DEVICE_ERROR);
+  }
+
+  /* Set the shared memory to memory allocated for non-channel specific reads */
+  Status = SbiMpxySetShmem (
+             0,
+             (UINT64)gShmemVirt,
+             &OPhysHi,
+             &OPhysLo,
+             TRUE /* Read back the old address */
+             );
+
+  if (EFI_ERROR (Status)) {
+    return (EFI_DEVICE_ERROR);
+  }
+
+  Ret = SbiCall (
+          SBI_EXT_MPXY,
+          SBI_EXT_MPXY_GET_CHANNEL_IDS,
+          1,
+          StartIndex
+          );
+
+  if (Ret.Error != SBI_SUCCESS) {
+    return TranslateError (Ret.Error);
+  }
+
+  /* Index 0 contains number of channels pending to be read */
+  if (Shmem[0] == 0) {
+    *Remaining = 0;
+  }
+
+  /* Number of channels returned */
+  if (Shmem[1] > 0) {
+    for (i = 0; i < Shmem[1]; i++) {
+      ChannelList[i] = Shmem[i+2];
+    }
+  }
+
+  *Returned = Shmem[1];
+
+  /* Switch back to old shared memory */
+  Status = SbiMpxySetShmem (
+             OPhysHi,
+             OPhysLo,
+             NULL,
+             NULL,
+             FALSE /* Read back the old address */
+             );
+
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Read multiple attributes from a specified channel.
+
+  @param[in]   ChannelId    Channel ID to query.
+  @param[in]   BaseAttrId   Starting attribute ID.
+  @param[in]   NrAttrs      Number of attributes to read.
+  @param[out]  Attrs        Buffer to receive attributes.
+
+  @retval EFI_SUCCESS       Attributes successfully read.
+  @retval EFI_DEVICE_ERROR  MPXY not initialized or SBI call failed.
+**/
+EFI_STATUS
+EFIAPI
+SbiMpxyReadChannelAttrs (
+  IN UINTN    ChannelId,
+  IN UINT32   BaseAttrId,
+  IN UINT32   NrAttrs,
+  OUT UINT32  *Attrs
+  )
+{
+  UINT64      OPhysHi, OPhysLo;
+  EFI_STATUS  Status;
+  SBI_RET     Ret;
+
+  if (!gMpxyLibInitialized) {
+    return (EFI_DEVICE_ERROR);
+  }
+
+  /* Set the shared memory to memory allocated for non-channel specific reads */
+  Status = SbiMpxySetShmem (
+             0,
+             (UINT64)gShmemVirt,
+             &OPhysHi,
+             &OPhysLo,
+             TRUE /* Read back the old address */
+             );
+
+  if (EFI_ERROR (Status)) {
+    return (EFI_DEVICE_ERROR);
+  }
+
+  Ret = SbiCall (
+          SBI_EXT_MPXY,
+          SBI_EXT_MPXY_READ_ATTRS,
+          3,
+          ChannelId,
+          BaseAttrId, /* Base attribute Id */
+          NrAttrs     /* Number of attributes */
+          );
+
+  if (Ret.Error != SBI_SUCCESS) {
+    return TranslateError (Ret.Error);
+  }
+
+  CopyMem (
+    Attrs,
+    gShmemVirt,
+    sizeof (UINT32) * NrAttrs
+    );
+
+  /* Switch back to old shared memory */
+  Status = SbiMpxySetShmem (
+             OPhysHi,
+             OPhysLo,
+             NULL,
+             NULL,
+             FALSE /* Read back the old address */
+             );
+
+  if (EFI_ERROR (Status)) {
+    return Status;
+  }
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Initialize the MPXY library and shared memory.
+
+  @retval EFI_SUCCESS         Successfully initialized.
+  @retval EFI_OUT_OF_RESOURCES Memory allocation failed.
+  @retval EFI_DEVICE_ERROR     SBI calls failed.
+**/
+EFI_STATUS
+EFIAPI
+SbiMpxyInit (
+  VOID
+  )
+{
+  VOID        *SbiShmem;
+  UINTN       NrEfiPages;
+  EFI_STATUS  Status;
+  UINT64      ShmemSize;
+
+  if (SbiMpxyShmemInitialized ()) {
+    return EFI_SUCCESS;
+  }
+
+  Status = SbiProbeExtension (SBI_EXT_MPXY);
+  ASSERT_EFI_ERROR (Status);
+
+  Status = SbiMpxyGetShmemSize (&ShmemSize);
+  if (EFI_ERROR (Status)) {
+    DEBUG ((
+      DEBUG_WARN,
+      "%a: Failed to get the shared memory size\n",
+      __func__
+      ));
+    return 0;
+  }
+
+  DEBUG ((
+    DEBUG_WARN,
+    "%a: Shared memory size to be allocated: %lu bytes\n",
+    __func__,
+    ShmemSize
+    ));
+
+  NrEfiPages = (ShmemSize / EFI_PAGE_SIZE) + 1;
+  gShmemSize = ShmemSize;
+
+  SbiShmem = AllocateAlignedPages (NrEfiPages, EFI_PAGE_SIZE);
+  if (SbiShmem == NULL) {
+    return EFI_OUT_OF_RESOURCES;
+  }
+
+  Status = SbiMpxySetShmem (
+                 0,
+                 (UINT64)SbiShmem,
+                 NULL,
+                 NULL,
+                 FALSE /* Not interested in old memory */
+                 );
+  if (EFI_ERROR (Status)) {
+    FreeAlignedPages (SbiShmem, NrEfiPages);
+    return EFI_DEVICE_ERROR;
+  }
+
+  gShmemVirt          = SbiShmem;
+  gNrShmemPages       = NrEfiPages;
+  gMpxyLibInitialized = TRUE;
+
+  return EFI_SUCCESS;
+}
+
+/**
+  De-initialize MPXY library and release shared memory.
+
+  @retval EFI_SUCCESS            Successfully deinitialized.
+  @retval EFI_INVALID_PARAMETER  Library not initialized.
+  @retval EFI_DEVICE_ERROR       Failed to disable memory.
+**/
+EFI_STATUS
+EFIAPI
+SbiMpxyDeinit (
+  VOID
+  )
+{
+  EFI_STATUS  Status;
+
+  if (!SbiMpxyShmemInitialized ()) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  /* Ref count is zero. Release the memory */
+  Status = SbiMpxyDisableShmem ();
+  if (EFI_ERROR (Status)) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  FreeAlignedPages (gShmemVirt, gNrShmemPages);
+
+  return EFI_SUCCESS;
+}
+
+/**
+  Send a message to an MPXY channel and receive response.
+
+  @param[in]  ChannelId      ID of the channel.
+  @param[in]  MessageId      Message type identifier.
+  @param[in]  Message        Pointer to message payload.
+  @param[in]  MessageDataLen Length of message payload.
+  @param[out] Response       Pointer to receive response.
+  @param[out] ResponseLen    Actual response length returned.
+
+  @retval EFI_SUCCESS            Message sent and response received.
+  @retval EFI_INVALID_PARAMETER  Invalid message length or uninitialized state.
+  @retval EFI_DEVICE_ERROR       SBI call failed.
+**/
+EFI_STATUS
+EFIAPI
+SbiMpxySendMessage (
+  IN UINTN   ChannelId,
+  IN UINTN   MessageId,
+  IN VOID    *Message,
+  IN UINTN   MessageDataLen,
+  OUT VOID   *Response,
+  OUT UINTN  *ResponseLen
+  )
+{
+  SBI_RET  Ret;
+  UINT64   Phys = gShmemPhysLo;
+
+  if (!SbiMpxyShmemInitialized ()) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  if (MessageDataLen >= gShmemSize) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  CopyMem ((VOID *)Phys, Message, MessageDataLen);
+
+  Ret = SbiCall (
+          SBI_EXT_MPXY,
+          SBI_EXT_MPXY_SEND_MSG_WITH_RESP,
+          3,
+          ChannelId,
+          MessageId,
+          MessageDataLen
+          );
+
+  if ((Ret.Error == SBI_SUCCESS) && Ret.Value) {
+    CopyMem (Response, (const VOID *)Phys, Ret.Value);
+    if (ResponseLen) {
+      *ResponseLen = Ret.Value;
+    }
+  }
+
+  return TranslateError (Ret.Error);
+}

--- a/MdePkg/Library/CommonRiscvMpxyLib/CommonRiscvMpxy.inf
+++ b/MdePkg/Library/CommonRiscvMpxyLib/CommonRiscvMpxy.inf
@@ -1,0 +1,28 @@
+# @file
+# Provides implementation of the library to communicate over SBI MPXY on RISCV architecture
+#
+# @copyright
+# Copyright (c) Ventana Micro Systems, Inc. All rights reserved.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION     = 1.27
+  BASE_NAME       = CommonRiscvMpxyLib
+  MODULE_UNI_FILE = CommonRiscvMpxy.uni
+  FILE_GUID       = 8E992DB5-4383-4023-A24E-7C99955BDE80
+  MODULE_TYPE     = BASE
+  VERSION_STRING  = 1.0
+  LIBRARY_CLASS   = CommonRiscvMpxyLib|DXE_DRIVER DXE_RUNTIME_DRIVER UEFI_APPLICATION UEFI_DRIVER MM_CORE_STANDALONE
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[Sources]
+  CommonRiscvMpxy.c
+
+[LibraryClasses]
+  DebugLib
+  RiscVSbiLib
+  SafeIntLib

--- a/MdePkg/Library/CommonRiscvMpxyLib/CommonRiscvMpxy.uni
+++ b/MdePkg/Library/CommonRiscvMpxyLib/CommonRiscvMpxy.uni
@@ -1,0 +1,15 @@
+// @file
+// Instance of SBI MPXY library for RISC-V architecutre.
+//
+// MpxyLib.
+//
+// Copyright (c) Ventana Micro Systems, Inc.
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+//
+
+
+#string STR_MODULE_ABSTRACT     #language en-US "Instance of SbiMpxy Library"
+
+#string STR_MODULE_DESCRIPTION  #language en-US "Library that provides implementation of SBI Mpxy on RISC-V architecture"
+

--- a/MdePkg/Library/DxeRiscvRasAgentClientLib/DxeRiscvRasAgentClient.c
+++ b/MdePkg/Library/DxeRiscvRasAgentClientLib/DxeRiscvRasAgentClient.c
@@ -1,0 +1,288 @@
+/** @file
+  This module provides communication with RAS Agent over RPMI/MPXY
+
+  Copyright (c) 2024, Ventana Micro Systems, Inc.
+
+  SPDX-License-Identifier: BSD-2-Clause-Patent
+**/
+
+#include <Base.h>
+#include <Uefi.h>
+
+#include <IndustryStandard/Acpi.h>
+
+#include <Protocol/AcpiTable.h>
+
+#include <Guid/EventGroup.h>
+
+#include <Library/BaseLib.h>
+#include <Library/BaseMemoryLib.h>
+
+#include <Library/MemoryAllocationLib.h>
+#include <Library/UefiBootServicesTableLib.h>
+#include <Library/DebugLib.h>
+#include <Library/PcdLib.h>
+#include <Library/SafeIntLib.h>
+#include <Library/BaseRiscVSbiLib.h>
+
+#include <Library/DxeRiscvMpxy.h>
+#include <Library/DxeRasAgentClient.h>
+
+#define MAX_SOURCES    512
+#define MAX_DESC_SIZE  1024
+
+/* RAS Agent Services on MPXY/RPMI */
+#define RAS_GET_NUM_ERR_SRCS      0x1
+#define RAS_GET_ERR_SRCS_ID_LIST  0x2
+#define RAS_GET_ERR_SRC_DESC      0x3
+
+#define __packed32  __attribute__((packed,aligned(__alignof__(UINT32))))
+
+typedef struct __packed32 {
+  UINT32    status;
+  UINT32    flags;
+  UINT32    remaining;
+  UINT32    returned;
+} RasRpmiRespHeader;
+
+typedef struct __packed32 {
+  RasRpmiRespHeader    RespHdr;
+  UINT32               ErrSourceList[MAX_SOURCES];
+} ErrorSourceListResp;
+
+typedef struct __packed32 {
+  RasRpmiRespHeader    RspHdr;
+  UINT8                desc[MAX_DESC_SIZE];
+} ErrDescResp;
+
+static ErrorSourceListResp  gErrorSourceListResp;
+static ErrDescResp          gErrDescResp;
+UINT32                      gMpxyChannelId = 0;
+
+STATIC
+EFI_STATUS
+EFIAPI
+ProbeRasAgentMpxyChannelId (
+  OUT UINT32  *ChannelId
+  )
+{
+  #define MAX_MPXY_CHANNELS  64
+  UINTN       ChannelList[MAX_MPXY_CHANNELS];
+  UINTN       Returned, Remaining, StartIndex = 0;
+  EFI_STATUS  Status;
+  BOOLEAN     Found = FALSE, ParsingDone = FALSE;
+  UINTN       i, Id;
+  UINT32      RasSrvGroup;
+
+  while (!ParsingDone) {
+    Status = SbiMpxyGetChannelList (
+               StartIndex, /* Start index */
+               &ChannelList[0],
+               &Remaining,
+               &Returned
+               );
+
+    if (Status != EFI_SUCCESS) {
+      return Status;
+    }
+
+    /* This read has returned zero and we still haven't got what we need */
+    if (Returned == 0) {
+      return EFI_UNSUPPORTED;
+    }
+
+    for (i = 0; i < Returned; i++) {
+      Id     = ChannelList[0];
+      Status = SbiMpxyReadChannelAttrs (
+                 Id,
+                 MPXY_MSG_PROTO_ATTR_START, /* Base attribute Id */
+                 1,                         /* Number of attributes to be read */
+                 &RasSrvGroup
+                 );
+
+      if (Status != EFI_SUCCESS) {
+        continue;
+      }
+
+      if (RasSrvGroup == 0xC) {
+        Found       = TRUE;
+        ParsingDone = TRUE;
+        break;
+      }
+    }
+
+    /* Read if some more to be read else we are done parsing */
+    if (Remaining) {
+      StartIndex = Returned;
+      continue;
+    } else {
+      ParsingDone = TRUE;
+    }
+  }
+
+  if (Found == TRUE) {
+    *ChannelId = Id;
+    DEBUG ((
+      DEBUG_INFO,
+      "Found RAS MPXY channel: %x\n",
+      Id
+      ));
+  }
+
+  return Status;
+}
+
+EFI_STATUS
+EFIAPI
+GetRasAgentMpxyChannelId (
+  OUT UINT32  *ChannelId
+  )
+{
+  return ProbeRasAgentMpxyChannelId (ChannelId);
+}
+
+EFI_STATUS
+EFIAPI
+RacInit (
+  VOID
+  )
+{
+  if (GetRasAgentMpxyChannelId (&gMpxyChannelId) != EFI_SUCCESS) {
+    return EFI_NOT_READY;
+  }
+
+  if (SbiMpxyInit () != EFI_SUCCESS) {
+    return EFI_NOT_READY;
+  }
+
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+EFIAPI
+RacGetNumberErrorSources (
+  UINT32  *NumErrorSources
+  )
+{
+  struct __packed32 _NumErrSrc {
+    RasRpmiRespHeader    RespHdr;
+    UINT32               NumErrorSources;
+  } RasMsgBuf;
+
+  EFI_STATUS         Status;
+  RasRpmiRespHeader  *RespHdr = &RasMsgBuf.RespHdr;
+  UINTN              RespLen  = sizeof (RasMsgBuf);
+
+  ZeroMem (&RasMsgBuf, sizeof (RasMsgBuf));
+
+  Status = SbiMpxySendMessage (
+             gMpxyChannelId,
+             RAS_GET_NUM_ERR_SRCS,
+             &RasMsgBuf,
+             sizeof (UINT32),
+             (VOID *)&RasMsgBuf,
+             &RespLen
+             );
+  if (Status != EFI_SUCCESS) {
+    return Status;
+  }
+
+  if (RespHdr->status != 0) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  *NumErrorSources = RasMsgBuf.NumErrorSources;
+
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+EFIAPI
+RacGetErrorSourceIDList (
+  OUT UINT32  **ErrorSourceList,
+  OUT UINT32  *NumSources
+  )
+{
+  UINT32             *RespData = &gErrorSourceListResp.ErrSourceList[0];
+  RasRpmiRespHeader  *RespHdr  = &gErrorSourceListResp.RespHdr;
+  EFI_STATUS         Status;
+  UINTN              RespLen = sizeof (gErrorSourceListResp);
+
+  ZeroMem (&gErrorSourceListResp, sizeof (gErrorSourceListResp));
+
+  if (!ErrorSourceList) {
+    return EFI_INVALID_PARAMETER;
+  }
+
+  Status = SbiMpxySendMessage (
+             gMpxyChannelId,
+             RAS_GET_ERR_SRCS_ID_LIST,
+             &gErrorSourceListResp,
+             sizeof (gErrorSourceListResp),
+             &gErrorSourceListResp,
+             &RespLen
+             );
+
+  if (Status != EFI_SUCCESS) {
+    return Status;
+  }
+
+  if (RespHdr->status != 0) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  *NumSources      = RespHdr->returned;
+  *ErrorSourceList = RespData;
+
+  return EFI_SUCCESS;
+}
+
+EFI_STATUS
+EFIAPI
+RacGetErrorSourceDescriptor (
+  IN UINT32   SourceID,
+  OUT UINTN   *DescriptorType,
+  OUT VOID    **ErrorDescriptor,
+  OUT UINT32  *ErrorDescriptorSize
+  )
+{
+  UINTN              RespLen = sizeof (gErrDescResp);
+  EFI_STATUS         Status;
+  RasRpmiRespHeader  *RspHdr = &gErrDescResp.RspHdr;
+  UINT8              *desc   = &gErrDescResp.desc[0];
+  UINT32             *EID    = (UINT32 *)&gErrDescResp;
+
+  ZeroMem (&gErrDescResp, sizeof (gErrDescResp));
+
+  *EID = SourceID;
+
+  Status = SbiMpxySendMessage (
+             gMpxyChannelId,
+             RAS_GET_ERR_SRC_DESC,
+             &gErrDescResp,
+             sizeof (gErrDescResp),
+             &gErrDescResp,
+             &RespLen
+             );
+
+  if (Status != EFI_SUCCESS) {
+    return Status;
+  }
+
+  if (RspHdr->status != 0) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  if (RspHdr->remaining != 0) {
+    return EFI_DEVICE_ERROR;
+  }
+
+  *DescriptorType = RspHdr->flags & ERROR_DESCRIPTOR_TYPE_MASK;
+
+  ASSERT (*DescriptorType < MAX_ERROR_DESCRIPTOR_TYPES);
+
+  *ErrorDescriptor     = (VOID *)desc;
+  *ErrorDescriptorSize = RspHdr->returned;
+
+  return EFI_SUCCESS;
+}

--- a/MdePkg/Library/DxeRiscvRasAgentClientLib/DxeRiscvRasAgentClient.c
+++ b/MdePkg/Library/DxeRiscvRasAgentClientLib/DxeRiscvRasAgentClient.c
@@ -17,6 +17,7 @@
 
 #include <Library/BaseLib.h>
 #include <Library/BaseMemoryLib.h>
+#include <Protocol/MmCommunication2.h>
 
 #include <Library/MemoryAllocationLib.h>
 #include <Library/UefiBootServicesTableLib.h>
@@ -35,6 +36,12 @@
 #define RAS_GET_NUM_ERR_SRCS      0x1
 #define RAS_GET_ERR_SRCS_ID_LIST  0x2
 #define RAS_GET_ERR_SRC_DESC      0x3
+
+#define MM_COMMUNICATE_HEADER_SIZE  (OFFSET_OF(EFI_MM_COMMUNICATE_HEADER, Data))
+
+STATIC EFI_MM_COMMUNICATION2_PROTOCOL  *mMmCommunication2 = NULL;
+
+EFI_STATUS (EFIAPI *gSendCommand)(VOID *CommBuffer, UINTN CmdLen, UINTN *RespLen, UINT8 FuncId);
 
 #define __packed32  __attribute__((packed,aligned(__alignof__(UINT32))))
 
@@ -141,18 +148,98 @@ GetRasAgentMpxyChannelId (
   return ProbeRasAgentMpxyChannelId (ChannelId);
 }
 
+/**
+  TODO: This is a placeholder method that sends a RAS command to the SMM handler
+  via MM communication, for now this will return EFI_NOT_FOUND. When the downstream
+  logic that will handle the MM Communication calls is merged then this method
+  should be updated.
+
+  @param[in,out] CommBuffer   Command and response buffer.
+  @param[in]     CmdLen       Command length.
+  @param[out]    RespLen      Length of response received.
+  @param[in]     FuncId       Function ID for the RAS operation.
+
+  @retval EFI_SUCCESS         Command sent and response received successfully.
+  @retval EFI_OUT_OF_RESOURCES  Allocation failure.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+RacSendMMCommand (
+  VOID   *CommBuffer,
+  UINTN  CmdLen,
+  UINTN  *RespLen,
+  UINT8  FuncId
+  )
+{
+  return EFI_NOT_FOUND;
+}
+
+/**
+  Sends a RAS command using SBI MPXY messaging.
+
+  @param[in,out] CommBuffer   Buffer for both command and response.
+  @param[in]     CmdLen       Length of command data.
+  @param[out]    RespLen      Length of response data.
+  @param[in]     FuncId       Function ID for the command.
+
+  @retval EFI_SUCCESS         Communication successful.
+**/
+STATIC
+EFI_STATUS
+EFIAPI
+RacSendPassThroughCommand (
+  VOID   *CommBuffer,
+  UINTN  CmdLen,
+  UINTN  *RespLen,
+  UINT8  FuncId
+  )
+{
+  EFI_STATUS  Status;
+
+  Status = SbiMpxySendMessage (
+             gMpxyChannelId,
+             FuncId,
+             CommBuffer,
+             CmdLen,
+             CommBuffer,
+             RespLen
+             );
+
+  return Status;
+}
+
 EFI_STATUS
 EFIAPI
 RacInit (
   VOID
   )
 {
-  if (GetRasAgentMpxyChannelId (&gMpxyChannelId) != EFI_SUCCESS) {
-    return EFI_NOT_READY;
-  }
+  EFI_STATUS  Status;
+  if (!PcdGetBool (PcdMMPassThroughEnable)) {
+    Status = gBS->LocateProtocol (
+                    &gEfiMmCommunication2ProtocolGuid,
+                    NULL,
+                    (VOID **)&mMmCommunication2
+                    );
 
-  if (SbiMpxyInit () != EFI_SUCCESS) {
-    return EFI_NOT_READY;
+    if (EFI_ERROR (Status)) {
+      return Status;
+    }
+
+    gSendCommand = RacSendMMCommand;
+  } else {
+    if (SbiMpxyInit () != EFI_SUCCESS) {
+      return EFI_NOT_READY;
+    }
+
+    if (GetRasAgentMpxyChannelId (&gMpxyChannelId) != EFI_SUCCESS) {
+      return EFI_NOT_READY;
+    }
+
+    DEBUG ((DEBUG_ERROR, "Rac Init Done\n"));
+
+    gSendCommand = RacSendPassThroughCommand;
   }
 
   return EFI_SUCCESS;
@@ -175,14 +262,7 @@ RacGetNumberErrorSources (
 
   ZeroMem (&RasMsgBuf, sizeof (RasMsgBuf));
 
-  Status = SbiMpxySendMessage (
-             gMpxyChannelId,
-             RAS_GET_NUM_ERR_SRCS,
-             &RasMsgBuf,
-             sizeof (UINT32),
-             (VOID *)&RasMsgBuf,
-             &RespLen
-             );
+  Status = gSendCommand (&RasMsgBuf, RespLen, &RespLen, RAS_GET_NUM_ERR_SRCS);
   if (Status != EFI_SUCCESS) {
     return Status;
   }
@@ -214,15 +294,7 @@ RacGetErrorSourceIDList (
     return EFI_INVALID_PARAMETER;
   }
 
-  Status = SbiMpxySendMessage (
-             gMpxyChannelId,
-             RAS_GET_ERR_SRCS_ID_LIST,
-             &gErrorSourceListResp,
-             sizeof (gErrorSourceListResp),
-             &gErrorSourceListResp,
-             &RespLen
-             );
-
+  Status = gSendCommand (&gErrorSourceListResp, RespLen, &RespLen, RAS_GET_ERR_SRCS_ID_LIST);
   if (Status != EFI_SUCCESS) {
     return Status;
   }
@@ -256,15 +328,7 @@ RacGetErrorSourceDescriptor (
 
   *EID = SourceID;
 
-  Status = SbiMpxySendMessage (
-             gMpxyChannelId,
-             RAS_GET_ERR_SRC_DESC,
-             &gErrDescResp,
-             sizeof (gErrDescResp),
-             &gErrDescResp,
-             &RespLen
-             );
-
+  Status = gSendCommand (&gErrDescResp, RespLen, &RespLen, RAS_GET_ERR_SRC_DESC);
   if (Status != EFI_SUCCESS) {
     return Status;
   }

--- a/MdePkg/Library/DxeRiscvRasAgentClientLib/DxeRiscvRasAgentClientLib.inf
+++ b/MdePkg/Library/DxeRiscvRasAgentClientLib/DxeRiscvRasAgentClientLib.inf
@@ -1,0 +1,30 @@
+# @file
+# Provides implementation of the library class RasAgentClient for RAS on RISC-V architecture
+#
+# @copyright
+# Copyright (c) Ventana Micro Systems, Inc.
+# SPDX-License-Identifier: BSD-2-Clause-Patent
+#
+##
+
+[Defines]
+  INF_VERSION     = 1.27
+  BASE_NAME       = DxeRasAgentClientLib
+  MODULE_UNI_FILE = DxeRiscvRasAgentClient.uni
+  FILE_GUID       = d1342a6d-43fb-41e4-a998-2227461c1901
+  MODULE_TYPE     = DXE_DRIVER
+  VERSION_STRING  = 1.0
+  LIBRARY_CLASS   = DxeRasAgentClientLib|DXE_DRIVER DXE_RUNTIME_DRIVER UEFI_APPLICATION UEFI_DRIVER
+
+[Packages]
+  MdePkg/MdePkg.dec
+
+[Sources]
+  DxeRiscvRasAgentClient.c
+
+[LibraryClasses]
+  DebugLib
+  UefiBootServicesTableLib
+  RiscVSbiLib
+  SafeIntLib
+  CommonRiscvMpxyLib

--- a/MdePkg/Library/DxeRiscvRasAgentClientLib/DxeRiscvRasAgentClientLib.inf
+++ b/MdePkg/Library/DxeRiscvRasAgentClientLib/DxeRiscvRasAgentClientLib.inf
@@ -28,3 +28,9 @@
   RiscVSbiLib
   SafeIntLib
   CommonRiscvMpxyLib
+
+[Protocols]
+  gEfiMmCommunication2ProtocolGuid
+
+[Pcd]
+  gEfiMdePkgTokenSpaceGuid.PcdMMPassThroughEnable

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -2519,6 +2519,10 @@
   # @Prompt IPMI Serial responder Software ID
   gEfiMdePkgTokenSpaceGuid.PcdIpmiSerialResponderAddress|0x20|UINT8|0x00000051
 
+  ## This option chooses between pass through and MM mode of communication.
+  # @Prompt Mode of transport for management service requests
+  gEfiMdePkgTokenSpaceGuid.PcdMMPassThroughEnable|TRUE|BOOLEAN|0x10000037
+
   ## This is requester's LUN for IPMI Serial.
   # @Prompt IPMI Serial requester LUN
   gEfiMdePkgTokenSpaceGuid.PcdIpmiSerialRequesterLun|0x0|UINT8|0x00000052

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -312,6 +312,10 @@
   #
   StackCheckLib|Include/Library/StackCheckLib.h
 
+  ##  @libraryclass Provides the RAS agent client to retrieve error source informations.
+  #
+  DxeRasAgentClientLib|Include/Library/DxeRasAgentClient.h
+
 [LibraryClasses.IA32, LibraryClasses.X64, LibraryClasses.AARCH64]
   ##  @libraryclass  Provides services to generate random number.
   #

--- a/MdePkg/MdePkg.dec
+++ b/MdePkg/MdePkg.dec
@@ -352,6 +352,7 @@
 [LibraryClasses.RISCV64]
   ##  @libraryclass  Provides function to make ecalls to SBI
   BaseRiscVSbiLib|Include/Library/BaseRiscVSbiLib.h
+  CommonRiscvMpxyLib|Include/Library/DxeRiscvMpxy.h
 
 [LibraryClasses.ARM, LibraryClasses.AARCH64]
   ##  @libraryclass  Provides an interface to Arm registers.

--- a/MdePkg/MdePkg.dsc
+++ b/MdePkg/MdePkg.dsc
@@ -216,6 +216,7 @@
   MdePkg/Library/BaseRiscVSbiLib/BaseRiscVSbiLib.inf
   MdePkg/Library/BaseSerialPortLibRiscVSbiLib/BaseSerialPortLibRiscVSbiLib.inf
   MdePkg/Library/BaseSerialPortLibRiscVSbiLib/BaseSerialPortLibRiscVSbiLibRam.inf
+  MdePkg/Library/CommonRiscvMpxyLib/CommonRiscvMpxy.inf
 
 [Components.LOONGARCH64]
   MdePkg/Library/PeiServicesTablePointerLibKs0/PeiServicesTablePointerLibKs0.inf

--- a/MdePkg/MdePkg.dsc
+++ b/MdePkg/MdePkg.dsc
@@ -217,6 +217,7 @@
   MdePkg/Library/BaseSerialPortLibRiscVSbiLib/BaseSerialPortLibRiscVSbiLib.inf
   MdePkg/Library/BaseSerialPortLibRiscVSbiLib/BaseSerialPortLibRiscVSbiLibRam.inf
   MdePkg/Library/CommonRiscvMpxyLib/CommonRiscvMpxy.inf
+  MdePkg/Library/DxeRiscvRasAgentClientLib/DxeRiscvRasAgentClientLib.inf
 
 [Components.LOONGARCH64]
   MdePkg/Library/PeiServicesTablePointerLibKs0/PeiServicesTablePointerLibKs0.inf

--- a/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
+++ b/OvmfPkg/RiscVVirt/RiscVVirtQemu.dsc
@@ -99,6 +99,8 @@
   QemuFwCfgSimpleParserLib|OvmfPkg/Library/QemuFwCfgSimpleParserLib/QemuFwCfgSimpleParserLib.inf
   QemuLoadImageLib|OvmfPkg/Library/GenericQemuLoadImageLib/GenericQemuLoadImageLib.inf
 
+  CommonRiscvMpxyLib|MdePkg/Library/CommonRiscvMpxyLib/CommonRiscvMpxy.inf
+  DxeRasAgentClientLib|MdePkg/Library/DxeRiscvRasAgentClientLib/DxeRiscvRasAgentClientLib.inf
   TimerLib|UefiCpuPkg/Library/BaseRiscV64CpuTimerLib/BaseRiscV64CpuTimerLib.inf
   VirtNorFlashDeviceLib|OvmfPkg/Library/VirtNorFlashDeviceLib/VirtNorFlashDeviceLib.inf
   VirtNorFlashPlatformLib|OvmfPkg/RiscVVirt/Library/VirtNorFlashPlatformLib/VirtNorFlashDeviceTreeLib.inf
@@ -518,6 +520,7 @@
   #
   OvmfPkg/PlatformHasAcpiDtDxe/PlatformHasAcpiDtDxe.inf
   MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf
+  MdeModulePkg/Universal/Acpi/AcpiHardwareErrorTableDxe/HardwareErrorSourceTableDxe.inf
   OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf {
     <LibraryClasses>
       NULL|OvmfPkg/Fdt/FdtPciPcdProducerLib/FdtPciPcdProducerLib.inf

--- a/OvmfPkg/RiscVVirt/RiscVVirtQemu.fdf
+++ b/OvmfPkg/RiscVVirt/RiscVVirtQemu.fdf
@@ -176,6 +176,7 @@ INF  OvmfPkg/SmbiosPlatformDxe/SmbiosPlatformDxe.inf
 INF  OvmfPkg/PlatformHasAcpiDtDxe/PlatformHasAcpiDtDxe.inf
 INF  MdeModulePkg/Universal/Acpi/AcpiTableDxe/AcpiTableDxe.inf
 INF  MdeModulePkg/Universal/Acpi/BootGraphicsResourceTableDxe/BootGraphicsResourceTableDxe.inf
+INF  MdeModulePkg/Universal/Acpi/AcpiHardwareErrorTableDxe/HardwareErrorSourceTableDxe.inf
 INF  OvmfPkg/AcpiPlatformDxe/AcpiPlatformDxe.inf
 
 #


### PR DESCRIPTION
# Description

MdePkg: Enahancement to Mpxy MM Lib

1. Removed constructor and converted it to BASE lib such that it can be supported from within MM mode as well. Removed unnecessary lib dependencies.
2. Renamed to common lib as it is now common between MM and non MM

There are systems which contain RAS drivers within Management Mode environments. For these systems, the way to communicate RAS messages is different in that it sends messages over MM protocol instead of direct MPXY comms. In order to maintain common driver for both modes we are introducing a function pointer based method to carry out this communication based on a platform configurable PCD. PcdMMPassThroughEnable==True enables driver to bypass MM mode.

- [ ] Breaking change?
- [ ] Impacts security?
- [ ] Includes tests?

## How This Was Tested

qemu/build/riscv64-softmmu/qemu-system-riscv64
-accel tcg -m 4096 -smp 2
-serial mon:stdio
-d guest_errors -D ./qemu.log
-bios <PATH/TO/OPENSBI/fw_dynamic.bin>
-device virtio-gpu-pci -full-screen
-device qemu-xhci
-device usb-kbd
-blockdev node-name=pflash0,driver=file,read-only=on,filename=<PATH/TO/RISCV_VIRT_CODE.fd>
-blockdev node-name=pflash1,driver=file,filename=<PATH/TO/RISCV_VIRT_VARS.fd>
-M virt,pflash0=pflash0,pflash1=pflash1,rpmi=true,ras=true,aia=aplic-imsic
-kernel <PATH/TO/KERNLE/Image>
-initrd <PATH/TO/ROOTFS>
-append "root=/dev/ram rw console=ttyS0 earlycon=uart8250,mmio,0x10000000"

## Integration Instructions

N/A
